### PR TITLE
Add entity load check on mention objects

### DIFF
--- a/modules/social_features/social_mentions/social_mentions.tokens.inc
+++ b/modules/social_features/social_mentions/social_mentions.tokens.inc
@@ -91,7 +91,7 @@ function social_mentions_tokens($type, $tokens, array $data, array $options, Bub
                 ->getStorage($target_type)
                 ->load($target_id);
 
-              if ($mention->getEntityTypeId() == 'mentions') {
+              if (isset($mention) && ($mention->getEntityTypeId() == 'mentions')) {
                 $loadUserId = User::load($mention->getMentionedUserID());
                 $user = $loadUserId->getDisplayName();
 


### PR DESCRIPTION
Fix null reference when social mention object can't be loaded

## Problem
When running the cron-job on my opensocial installation, I get the following backtrace:

```
[31-Mar-2020 13:14:11 Europe/Berlin] Error: Call to a member function getMentionedEntity() o
n null in /mnt/data/opensocial/html/profiles/contrib/social/modules/social_features/social_m
entions/social_mentions.tokens.inc on line 115 #0 [internal function]: social_mentions_token
s('social_mentions', Array, Array, Array, Object(Drupal\Core\Render\BubbleableMetadata))
#1 /mnt/data/opensocial/html/core/lib/Drupal/Core/Extension/ModuleHandler.php(403): call_use
r_func_array('social_mentions...', Array)
#2 /mnt/data/opensocial/html/core/lib/Drupal/Core/Utility/Token.php(304): Drupal\Core\Extens
ion\ModuleHandler->invokeAll('tokens', Array)
#3 /mnt/data/opensocial/html/core/lib/Drupal/Core/Utility/Token.php(196): Drupal\Core\Utilit
y\Token->generate('social_mentions', Array, Array, Array, Object(Drupal\Core\Render\Bubbleab
leMetadata))
#4 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/src/Act
ivityFactory.php(519): Drupal\Core\Utility\Token->replace('<p><a href="[me...', Array, Array
, Object(Drupal\Core\Render\BubbleableMetadata))
#5 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/src/ActivityFactory.php(443): Drupal\activity_creator\ActivityFactory->processTokens(Array, false, Object(Drupal\message\Entity\Message))
#6 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/src/ActivityFactory.php(144): Drupal\activity_creator\ActivityFactory->getMessageText(Object(Drupal\message\Entity\Message))
#7 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/src/ActivityFactory.php(72): Drupal\activity_creator\ActivityFactory->getFieldOutputText(Object(Drupal\message\Entity\Message))
#8 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/src/ActivityFactory.php(47): Drupal\activity_creator\ActivityFactory->buildActivities(Array)
#9 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/src/Plugin/QueueWorker/ActivityWorkerActivities.php(61): Drupal\activity_creator\ActivityFactory->createActivities(Array)
#10 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/activity_creator.module(379): Drupal\activity_creator\Plugin\QueueWorker\ActivityWorkerActivities->processItem(Array)
#11 /mnt/data/opensocial/html/profiles/contrib/social/modules/custom/activity_creator/activity_creator.module(348): activity_creator_empty_queue()
#12 [internal function]: activity_creator_cron()
#13 /mnt/data/opensocial/html/core/lib/Drupal/Core/Extension/ModuleHandler.php(392): call_user_func_array('activity_creato...', Array)
#14 /mnt/data/opensocial/html/core/lib/Drupal/Core/Cron.php(236): Drupal\Core\Extension\ModuleHandler->invoke('activity_creato...', 'cron')
#15 /mnt/data/opensocial/html/core/lib/Drupal/Core/Cron.php(134): Drupal\Core\Cron->invokeCronHandlers()
#16 /mnt/data/opensocial/html/core/lib/Drupal/Core/ProxyClass/Cron.php(75): Drupal\Core\Cron->run()
#17 /mnt/data/opensocial/html/core/modules/system/src/CronController.php(46): Drupal\Core\ProxyClass\Cron->run()
#18 [internal function]: Drupal\system\CronController->run()
#19 /mnt/data/opensocial/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)
#20 /mnt/data/opensocial/html/core/lib/Drupal/Core/Render/Renderer.php(573): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#21 /mnt/data/opensocial/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#22 /mnt/data/opensocial/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array)
#23 /mnt/data/opensocial/vendor/symfony/http-kernel/HttpKernel.php(151): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#24 /mnt/data/opensocial/vendor/symfony/http-kernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#25 /mnt/data/opensocial/html/core/lib/Drupal/Core/StackMiddleware/Session.php(57): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#26 /mnt/data/opensocial/html/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(47): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#27 /mnt/data/opensocial/html/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#28 /mnt/data/opensocial/html/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#29 /mnt/data/opensocial/html/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(47): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#30 /mnt/data/opensocial/html/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(52): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#31 /mnt/data/opensocial/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#32 /mnt/data/opensocial/html/core/lib/Drupal/Core/DrupalKernel.php(694): Stack\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#33 /mnt/data/opensocial/html/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#34 {main}
```

## Solution
Add a check to see that the mention object is correctly loaded, before deferencing it.